### PR TITLE
ENH: Add Linux aarch64 and ppc64le builds

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -23,27 +23,27 @@ jobs:
       linux_aarch64_root_base6.36.8root_cxx_standard20:
         CONFIG: linux_aarch64_root_base6.36.8root_cxx_standard20
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_root_base6.38.0root_cxx_standard20:
         CONFIG: linux_aarch64_root_base6.38.0root_cxx_standard20
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_root_base6.38.0root_cxx_standard23:
         CONFIG: linux_aarch64_root_base6.38.0root_cxx_standard23
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_ppc64le_root_base6.36.8root_cxx_standard20:
         CONFIG: linux_ppc64le_root_base6.36.8root_cxx_standard20
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le:alma9
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_ppc64le_root_base6.38.0root_cxx_standard20:
         CONFIG: linux_ppc64le_root_base6.38.0root_cxx_standard20
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le:alma9
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_ppc64le_root_base6.38.0root_cxx_standard23:
         CONFIG: linux_ppc64le_root_base6.38.0root_cxx_standard23
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le:alma9
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -23,15 +23,15 @@ jobs:
       osx_arm64_root_base6.36.8root_cxx_standard20:
         CONFIG: osx_arm64_root_base6.36.8root_cxx_standard20
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15-arm64
+        VMIMAGE: macOS-15
       osx_arm64_root_base6.38.0root_cxx_standard20:
         CONFIG: osx_arm64_root_base6.38.0root_cxx_standard20
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15-arm64
+        VMIMAGE: macOS-15
       osx_arm64_root_base6.38.0root_cxx_standard23:
         CONFIG: osx_arm64_root_base6.38.0root_cxx_standard23
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15-arm64
+        VMIMAGE: macOS-15
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_aarch64_root_base6.36.8root_cxx_standard20.yaml
+++ b/.ci_support/linux_aarch64_root_base6.36.8root_cxx_standard20.yaml
@@ -11,7 +11,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 root_base:
 - 6.36.8
 root_cxx_standard:

--- a/.ci_support/linux_aarch64_root_base6.38.0root_cxx_standard20.yaml
+++ b/.ci_support/linux_aarch64_root_base6.38.0root_cxx_standard20.yaml
@@ -11,7 +11,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 root_base:
 - 6.38.0
 root_cxx_standard:

--- a/.ci_support/linux_aarch64_root_base6.38.0root_cxx_standard23.yaml
+++ b/.ci_support/linux_aarch64_root_base6.38.0root_cxx_standard23.yaml
@@ -11,7 +11,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 root_base:
 - 6.38.0
 root_cxx_standard:

--- a/.ci_support/linux_ppc64le_root_base6.36.8root_cxx_standard20.yaml
+++ b/.ci_support/linux_ppc64le_root_base6.36.8root_cxx_standard20.yaml
@@ -11,7 +11,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 root_base:
 - 6.36.8
 root_cxx_standard:

--- a/.ci_support/linux_ppc64le_root_base6.38.0root_cxx_standard20.yaml
+++ b/.ci_support/linux_ppc64le_root_base6.38.0root_cxx_standard20.yaml
@@ -11,7 +11,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 root_base:
 - 6.38.0
 root_cxx_standard:

--- a/.ci_support/linux_ppc64le_root_base6.38.0root_cxx_standard23.yaml
+++ b/.ci_support/linux_ppc64le_root_base6.38.0root_cxx_standard23.yaml
@@ -11,7 +11,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 root_base:
 - 6.38.0
 root_cxx_standard:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -56,6 +56,9 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --test skip"
+fi
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -87,6 +87,10 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     echo "rattler-build does not currently support debug mode"
 else
 
+    if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --test skip"
+    fi
+
     rattler-build build --recipe ./recipe \
         -m ./.ci_support/${CONFIG}.yaml \
         ${EXTRA_CB_OPTIONS:-} \

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,12 +1,17 @@
+build_platform:
+  linux_aarch64: linux_64
+  linux_ppc64le: linux_64
+  osx_arm64: osx_64
+conda_build:
+  error_overlinking: true
 conda_build_tool: rattler-build
 conda_install_tool: pixi
+conda_forge_output_validation: true
 github:
   branch_name: main
   tooling_branch_name: main
-conda_build:
-  error_overlinking: true
-conda_forge_output_validation: true
 provider:
   linux_aarch64: default
   linux_ppc64le: default
-  osx_arm64: azure
+  osx_arm64: default
+test: native_and_emulated

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -14,7 +14,7 @@ source:
     - add-missing-algorithm-include.patch
 
 build:
-  number: 0
+  number: 1
   skip:
     - win
   script:
@@ -57,8 +57,7 @@ tests:
       - gunzip z_ee.hep.gz
       - DelphesSTDHEP "${PREFIX}"/cards/delphes_card_CMS.tcl delphes_output.root z_ee.hep
 
-      - 
-        # avoid lots of output to stdout
+      # avoid lots of output to stdout
       - root -l -b -q "${PREFIX}"/examples/Example1.C'("delphes_output.root")' &> /dev/null
       - root -l -b -q "${PREFIX}"/examples/Example2.C'("delphes_output.root")'
       - root -l -b -q "${PREFIX}"/examples/Example3.C'("delphes_output.root")'

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,13 +1,12 @@
 context:
-  name: "delphes"
   version: "3.5.1"
 
 package:
-  name: ${{ name }}
+  name: "delphes"
   version: ${{ version }}
 
 source:
-  url: https://github.com/delphes/${{ name }}/archive/refs/tags/${{ version }}.tar.gz
+  url: https://github.com/delphes/delphes/archive/refs/tags/${{ version }}.tar.gz
   sha256: b60d26d2ee2c84b58fbf2cf397fabd0ef3e89d3a0546d843c4ada82cc802d787
   patches:
     # std::prev_permutation needs <algorithm>, not transitively included on osx
@@ -42,16 +41,16 @@ requirements:
     - ${{ pin_subpackage("delphes", upper_bound="x.x.x") }}
 
 tests:
-  - script:
-      # Running the 'DelphesXXX --help' commands results in exit code 1,
-      # so check for existence instead.
-      - test -f "${PREFIX}"/bin/DelphesHepMC2
-      - test -f "${PREFIX}"/bin/DelphesHepMC3
-      - test -f "${PREFIX}"/bin/DelphesLHEF
-      - test -f "${PREFIX}"/bin/DelphesPythia8
-      - test -f "${PREFIX}"/bin/DelphesROOT
-      - test -f "${PREFIX}"/bin/DelphesSTDHEP
+  - package_contents:
+      bin:
+        - DelphesHepMC2
+        - DelphesHepMC3
+        - DelphesLHEF
+        - DelphesPythia8
+        - DelphesROOT
+        - DelphesSTDHEP
 
+  - script:
       # N.B.: MUST be http not https (unfortunately)
       - curl -LO http://cp3.irmp.ucl.ac.be/downloads/z_ee.hep.gz
       - gunzip z_ee.hep.gz


### PR DESCRIPTION
* Add linux_aarch64 and linux_ppc64le to build_platform and build via cross compile from x86 (linux_64) to use Microsoft Azure Pipelines for the builds.
   - c.f. https://conda-forge.org/docs/maintainer/conda_forge_yml/#build-platform
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
