### PR TITLE
MNT: Use CMAKE_ARGS during build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,11 +23,11 @@ build:
     - grep -r -l "external/" examples/ | xargs sed -i 's|external/||g'  # [linux]
     - grep -r -l "external/" examples/ | xargs sed -i '' 's|external/||g'  # [osx]
 
-    - CXXFLAGS="${CXXFLAGS}" cmake -DCMAKE_INSTALL_PREFIX=$PREFIX -DPYTHIA8_DATA=$(pythia8-config --datadir) -S . -B build
+    - CXXFLAGS="${CXXFLAGS}" cmake ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=$PREFIX -DPYTHIA8_DATA=$(pythia8-config --datadir) -S . -B build
     - cmake build -LH
     - cmake --build build --clean-first --parallel="${CPU_COUNT}"
     - cmake --install build
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
* Use ${CMAKE_ARGS} for cmake builds.
   - c.f. https://conda-forge.org/docs/maintainer/knowledge_base/#using-cmake
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
